### PR TITLE
Make mtime datetime offset aware

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,12 @@
 
+3.0.4
+-----
+- Fix comparison between offset-aware and naive datetimes 
+
+3.0.3
+-----
+- Fix compatibility with itsdangerous 2.0+
+
 3.0.2
 -----
 - Fix a couple Python3 dict API changes.

--- a/flask_images/core.py
+++ b/flask_images/core.py
@@ -351,11 +351,13 @@ class Images(object):
                 abort(404) # Not found.
 
         raw_mtime = os.path.getmtime(path)
-        mtime = datetime.datetime.fromtimestamp(raw_mtime, tz=datetime.timezone.utc).replace(microsecond=0)
         # log.debug('last_modified: %r' % mtime)
         # log.debug('if_modified_since: %r' % request.if_modified_since)
-        if request.if_modified_since and request.if_modified_since >= mtime:
-            return '', 304
+        if request.if_modified_since:
+            tzinfo = request.if_modified_since.tzinfo
+            mtime = datetime.datetime.fromtimestamp(raw_mtime, tz=tzinfo).replace(microsecond=0)
+            if request.if_modified_since >= mtime:
+                return '', 304
         
         mode = query.get('mode')
 

--- a/flask_images/core.py
+++ b/flask_images/core.py
@@ -351,7 +351,7 @@ class Images(object):
                 abort(404) # Not found.
 
         raw_mtime = os.path.getmtime(path)
-        mtime = datetime.datetime.utcfromtimestamp(raw_mtime).replace(microsecond=0)
+        mtime = datetime.datetime.fromtimestamp(raw_mtime, tz=datetime.timezone.utc).replace(microsecond=0)
         # log.debug('last_modified: %r' % mtime)
         # log.debug('if_modified_since: %r' % request.if_modified_since)
         if request.if_modified_since and request.if_modified_since >= mtime:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
 
     name='Flask-Images',
-    version='3.0.3',
+    version='3.0.4',
     description='Dynamic image resizing for Flask.',
     url='http://github.com/mikeboers/Flask-Images',
         


### PR DESCRIPTION
Fix https://github.com/Club-Alpin-Annecy/collectives/issues/590 :

```
 File "/home/production/collectives-flask2/.env/lib/python3.9/site-packages/flask_images/core.py", line 357, in handle_request
    if request.if_modified_since and request.if_modified_since >= mtime:
TypeError: can't compare offset-naive and offset-aware datetimes
```
by using an offset-aware mtime.

See https://docs.python.org/3/library/datetime.html:
```
Warning

Because naive datetime objects are treated by many datetime methods as local times, it is preferred to use aware datetimes to represent times in UTC. As such, the recommended way to create an object representing a specific timestamp in UTC is by calling datetime.fromtimestamp(timestamp, tz=timezone.utc).
```
